### PR TITLE
Fix out of range values causing video glitches

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,7 @@ def lineplot(xs, ys_population, title, path='', xaxis='episode'):
 
 
 def write_video(frames, title, path=''):
-  frames = np.multiply(np.stack(frames, axis=0).transpose(0, 2, 3, 1), 255).astype(np.uint8)[:, :, :, ::-1]  # VideoWrite expects H x W x C in BGR
+  frames = np.multiply(np.stack(frames, axis=0).transpose(0, 2, 3, 1), 255).clip(0, 255).astype(np.uint8)[:, :, :, ::-1]  # VideoWrite expects H x W x C in BGR
   _, H, W, _ = frames.shape
   writer = cv2.VideoWriter(os.path.join(path, '%s.mp4' % title), cv2.VideoWriter_fourcc(*'mp4v'), 30., (W, H), True)
   for frame in frames:


### PR DESCRIPTION
Addresses #12, calling `.astype(uint8)` on negative values or values above 255 will result in garbled video output.