### PR TITLE
Update conda environment yaml configuration

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,9 @@ channels:
 dependencies:
   - plotly
   - pytorch
+  - torchvision
   - tqdm
+  - pip
   - pip:
     - gym
     - opencv-python


### PR DESCRIPTION
The current conda configuration `environment.yml` doesn't work out of the box as it is missing `torchvision` which is a required dependency and not installed automatically just having `pytorch`. I additionally added an explicit `pip` dependency so the following warning does not show:

```
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```